### PR TITLE
Feature/#7/pyokemon 37 공연 상세 가격 api

### DIFF
--- a/src/api/event/fetchers/get-event-booking.ts
+++ b/src/api/event/fetchers/get-event-booking.ts
@@ -1,0 +1,20 @@
+import baseClient from "@/api/client/base-client"
+
+import { Booking_sidebar } from "@/types/booking"
+
+export const getEventBooking = async (eventScheduleId: number): Promise<Booking_sidebar> => {
+  const response = await baseClient.get(
+    `http://localhost:8080/api/events/booking/${eventScheduleId}`
+  )
+  return response.data
+}
+
+// export const getSeat_class = async (
+//   eventScheduleId: bigint,
+//   seatGrade: string
+// ): Promise<Seat_class[]> => {
+//   const response = await baseClient.get(
+//     `http://localhost:8080/api/events/booking/${eventScheduleId}/${seatGrade}`
+//   );
+//   return response.data;
+// };

--- a/src/api/event/queries/use-get-event-booking.query.ts
+++ b/src/api/event/queries/use-get-event-booking.query.ts
@@ -1,0 +1,15 @@
+import { useQuery, UseQueryResult } from "@tanstack/react-query"
+
+import { Booking_sidebar } from "@/types/booking"
+
+import { getEventBooking } from "../fetchers/get-event-booking"
+
+export const useGetEventBookingQuery = (
+  eventScheduleId: number
+): UseQueryResult<Booking_sidebar> => {
+  return useQuery({
+    queryKey: ["eventBooking", eventScheduleId],
+    queryFn: () => getEventBooking(eventScheduleId),
+    enabled: Boolean(eventScheduleId),
+  })
+}

--- a/src/pages/event-detail/_component/booking-sidebar.tsx
+++ b/src/pages/event-detail/_component/booking-sidebar.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { differenceInCalendarDays, format, parseISO } from "date-fns"
+import { differenceInCalendarDays, format, isBefore, parseISO } from "date-fns"
 import { ko } from "date-fns/locale"
 import Calendar from "react-calendar"
 
@@ -20,7 +20,7 @@ const BookingSidebar = () => {
   const today = new Date()
   const ticketOpenAt = parseISO(event.ticketOpenAt)
   const diffDays = differenceInCalendarDays(ticketOpenAt, today)
-  const isOpen = diffDays < 0
+  const isOpen = isBefore(new Date(), ticketOpenAt) === false
 
   return (
     <article className="w-480">

--- a/src/pages/event-detail/event-detail-page.tsx
+++ b/src/pages/event-detail/event-detail-page.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react"
+import { useGetEventBookingQuery } from "@/api/event/queries/use-get-event-booking.query"
 import { useGetEventDetailQuery } from "@/api/event/queries/use-get-event-detail-query"
 import { useEventStore } from "@/store/event/event-store"
 import { format } from "date-fns"
@@ -7,7 +8,6 @@ import { useParams } from "react-router"
 
 import GenreBadge from "@/components/ui/genre-badge"
 
-// import { event } from "../../constants/event"
 import BookingSidebar from "./_component/booking-sidebar"
 
 const EventDetailPage = () => {
@@ -17,18 +17,24 @@ const EventDetailPage = () => {
   const handleMarkClick = () => {
     setIsMarked(!isMarked)
   }
-  const { data, isLoading } = useGetEventDetailQuery(Number(eventId))
+  const { data: event, isLoading } = useGetEventDetailQuery(Number(eventId))
+  const { data: booking } = useGetEventBookingQuery(event?.eventScheduleId ?? 0)
+  const prices = booking?.remainingSeatsByGrade
 
-  const { setEvent, event } = useEventStore()
+  const { setEvent } = useEventStore()
 
   useEffect(() => {
-    if (data) {
-      setEvent(data)
+    if (event) {
+      setEvent(event)
     }
-  }, [data, setEvent])
+  }, [event, setEvent])
 
-  if (isLoading || !event) {
-    return <div>Loading...</div> // 로딩 중 UI
+  if (isLoading) {
+    return <div>loading...</div>
+  }
+
+  if (!event || !prices) {
+    return <div>존재하지 않는 공연입니다.</div> // 로딩 중 UI
   }
 
   return (
@@ -73,15 +79,18 @@ const EventDetailPage = () => {
               <li>{event.ageLimit}세</li>
               <li>
                 <ul className="text-gray-700">
-                  <li>
-                    VIP <span className="font-bold text-black">198,000원</span>
-                  </li>
-                  <li>
-                    R <span className="font-bold text-black">178,000원</span>
-                  </li>
-                  <li>
-                    A <span className="font-bold text-black">148,000원</span>
-                  </li>
+                  {prices
+                    .filter((price) => price.price != 0)
+                    .map((price) => {
+                      return (
+                        <li key={price.seatGrade}>
+                          {price.seatGrade}{" "}
+                          <span className="font-bold text-black">
+                            {price.price.toLocaleString()}원
+                          </span>
+                        </li>
+                      )
+                    })}
                 </ul>
               </li>
             </ul>

--- a/src/types/booking.ts
+++ b/src/types/booking.ts
@@ -1,0 +1,8 @@
+export interface Booking_sidebar {
+  eventScheduleId: number
+  remainingSeatsByGrade: {
+    seatGrade: string
+    remainingSeats: number
+    price: number
+  }[]
+}

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,12 +1,13 @@
 export interface EventType {
   eventId: number
   title: string
-  ageLimit: number
+  ageLimit?: number
   venueName: string
   eventDate: string
   ticketOpenAt: string
   genre: string
   thumbnailUrl: string
-  description: string
+  description?: string
   eventScheduleId: number
+  venueId?: number
 }


### PR DESCRIPTION
## ✏️ 작업 개요  
이번 PR에서 작업한 내용을 간단히 요약해주세요.
공연 상세 가격 받아오기

## 🔨 작업 내용 상세
- 공연 상세 페이지에서 등급별 가격 받아오기
- event type의 `ageLimit` `description` `venueId` 는 optional로 수정

## 🔗 관련 이슈  
- Closes #이슈번호
- #7 

## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] Swagger UI에서 API 확인 완료
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수
- [ ] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
