### PR TITLE
[PYOKEMON-70] [feature] 공연 검색 UI/API 연동

### DIFF
--- a/src/api/event/fetchers/get-event-list.ts
+++ b/src/api/event/fetchers/get-event-list.ts
@@ -22,7 +22,7 @@ export const fetchEventToBeOpened = async () => {
   }
 }
 
-export const fetchEventlist = async (genre: string, page: number = 1, size: number = 8) => {
+export const fetchEventlist = async (genre: string, page: number = 1, size: number = 9) => {
   try {
     const res = await eventClient.get(`/api/events`, {
       params: { genre, page, size },
@@ -31,6 +31,24 @@ export const fetchEventlist = async (genre: string, page: number = 1, size: numb
     return res.data
   } catch (error) {
     console.error("이벤트 리스트 fetch 실패:", error)
+    throw error
+  }
+}
+
+export const fetchEventSearchlist = async (
+  keyword: string,
+  page: number = 1,
+  genre: string,
+  size: number = 9
+) => {
+  try {
+    const res = await eventClient.get(`/api/events/keyword`, {
+      params: { keyword, page, genre, size },
+    })
+    console.log(res.data)
+    return res.data
+  } catch (error) {
+    console.error("검색 실패:", error)
     throw error
   }
 }

--- a/src/api/event/queries/get-event-list-query.ts
+++ b/src/api/event/queries/get-event-list-query.ts
@@ -6,6 +6,7 @@ import { EventType } from "@/types/event"
 import {
   fetchEventlist,
   fetchEventOpenToday,
+  fetchEventSearchlist,
   fetchEventToBeOpened,
 } from "../fetchers/get-event-list"
 
@@ -27,5 +28,12 @@ export const useGetEventListQuery = (genre: string, page: number = 1) => {
   return useQuery<EventType[]>({
     queryKey: ["eventList", genre, page],
     queryFn: () => fetchEventlist(genre, page),
+  })
+}
+
+export const useGetEventSearchListQuery = (keyword: string, page: number = 1, genre: string) => {
+  return useQuery<EventType[]>({
+    queryKey: ["eventSearchList", keyword, page, genre],
+    queryFn: () => fetchEventSearchlist(keyword, page, genre),
   })
 }

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react"
 import { IoNotificationsOutline, IoPersonOutline, IoSearchOutline } from "react-icons/io5"
-import { Link, useLocation } from "react-router"
+import { Link, useLocation, useNavigate } from "react-router"
 
 import logo from "../../assets/images/logo.svg"
 import Notification from "../notification"
@@ -17,8 +17,14 @@ function Header() {
   const iconStyle = "text-black w-24 h-24"
 
   const [showSearchBar, setShowSearchBar] = useState(false)
+  const [keyword, setKeyword] = useState("")
+  const navigate = useNavigate()
   const [showNotification, setShowNotification] = useState(false)
-
+  const handleSearch = () => {
+    if (keyword.trim()) {
+      navigate(`/event/search?keyword=${keyword}`)
+    }
+  }
   return (
     <div className="flex bg-white h-100 w-full text-black items-center justify-between px-160 shadow-container">
       <Link to="/">
@@ -56,6 +62,11 @@ function Header() {
               style={{
                 opacity: showSearchBar ? 1 : 0,
                 width: showSearchBar ? "100%" : "0",
+              }}
+              value={keyword}
+              onChange={(e) => setKeyword(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleSearch()
               }}
             />
           </div>

--- a/src/pages/event-list-page.tsx
+++ b/src/pages/event-list-page.tsx
@@ -67,7 +67,7 @@ const EventListPage = () => {
         <Pagination
           current={page}
           total={eventList[0]?.total ?? 0}
-          pageSize={8}
+          pageSize={9}
           onChange={(p) => handlePageChange(p)}
         />
       </div>

--- a/src/pages/event-search-list-page.tsx
+++ b/src/pages/event-search-list-page.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react"
+import React, { useCallback, useState } from "react"
 import { useGetEventSearchListQuery } from "@/api/event/queries/get-event-list-query"
 import { GENRE_LIST, GENRE_MAP } from "@/constants/genre"
 import { useSearchParams } from "react-router"
@@ -20,26 +20,36 @@ const EventSearchListPage = () => {
     setSearchParams({ type, page: newPage.toString() })
   }
 
-  const handleGenreClick = (newType: string) => {
-    const currentType = searchParams.get("type") ?? ""
-    const nextParams = new URLSearchParams(searchParams)
+  const handleGenreClick = useCallback(
+    (newType: string) => {
+      const currentType = searchParams.get("type") ?? ""
+      const nextParams = new URLSearchParams(searchParams)
 
-    if (newType === "") {
-      nextParams.delete("type")
-    } else if (newType === currentType) {
-      nextParams.delete("type")
-    } else {
-      nextParams.set("type", newType)
-    }
+      if (newType === "") {
+        nextParams.delete("type")
+      } else if (newType === currentType) {
+        nextParams.delete("type")
+      } else {
+        nextParams.set("type", newType)
+      }
 
-    // 장르 바뀌면 페이지도 초기화
-    nextParams.delete("page")
+      // 장르 바뀌면 페이지도 초기화
+      nextParams.delete("page")
 
-    setSearchParams(nextParams)
-  }
+      setSearchParams(nextParams)
+    },
+    [searchParams, setSearchParams]
+  )
 
   if (isLoading || !eventList) return <div>Loading...</div>
   if (error) return <p>에러 발생!</p>
+  if (eventList.length === 0) {
+    return (
+      <div className="px-160 mb-48">
+        <p className="text-center py-48">검색 결과가 없습니다.</p>
+      </div>
+    )
+  }
 
   return (
     <div className="px-160 mb-48">
@@ -68,7 +78,7 @@ const EventSearchListPage = () => {
         <Pagination
           current={page}
           total={eventList[0]?.total ?? 0}
-          pageSize={8}
+          pageSize={9}
           onChange={(p) => handlePageChange(p)}
         />
       </div>

--- a/src/pages/event-search-list-page.tsx
+++ b/src/pages/event-search-list-page.tsx
@@ -1,0 +1,79 @@
+import React, { useState } from "react"
+import { useGetEventSearchListQuery } from "@/api/event/queries/get-event-list-query"
+import { GENRE_LIST, GENRE_MAP } from "@/constants/genre"
+import { useSearchParams } from "react-router"
+
+import GenreBadge from "@/components/ui/genre-badge"
+import Pagination from "@/components/ui/pagination"
+import EventPreviewCard from "@/components/event-preview-card/event-preview-card"
+
+const EventSearchListPage = () => {
+  const [searchParams, setSearchParams] = useSearchParams()
+  const type = searchParams.get("type") ?? ""
+  const page = Number(searchParams.get("page") ?? "1")
+  const genre = GENRE_MAP[type] ?? ""
+  const keyword = searchParams.get("keyword") ?? ""
+
+  const { data: eventList, isLoading, error } = useGetEventSearchListQuery(keyword, page, genre)
+
+  const handlePageChange = (newPage: number) => {
+    setSearchParams({ type, page: newPage.toString() })
+  }
+
+  const handleGenreClick = (newType: string) => {
+    const currentType = searchParams.get("type") ?? ""
+    const nextParams = new URLSearchParams(searchParams)
+
+    if (newType === "") {
+      nextParams.delete("type")
+    } else if (newType === currentType) {
+      nextParams.delete("type")
+    } else {
+      nextParams.set("type", newType)
+    }
+
+    // 장르 바뀌면 페이지도 초기화
+    nextParams.delete("page")
+
+    setSearchParams(nextParams)
+  }
+
+  if (isLoading || !eventList) return <div>Loading...</div>
+  if (error) return <p>에러 발생!</p>
+
+  return (
+    <div className="px-160 mb-48">
+      <h1 className="title-24-bold pt-48">공연 검색 결과</h1>
+
+      {/* filtering */}
+      <ul className="flex gap-12 py-24 flex-wrap">
+        {GENRE_LIST.map((genre) => {
+          const isActive = type === genre.type
+          return (
+            <li key={genre.title} onClick={() => handleGenreClick(genre.type)}>
+              <GenreBadge genre={genre.title} gray={!isActive} />
+            </li>
+          )
+        })}
+      </ul>
+
+      {/* event */}
+      <div className="grid grid-cols-3 gap-24">
+        {eventList.map((event, i) => {
+          return <EventPreviewCard key={i} event={event} />
+        })}
+      </div>
+
+      <div className="flex justify-center mt-12">
+        <Pagination
+          current={page}
+          total={eventList[0]?.total ?? 0}
+          pageSize={8}
+          onChange={(p) => handlePageChange(p)}
+        />
+      </div>
+    </div>
+  )
+}
+
+export default EventSearchListPage

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -6,6 +6,7 @@ import ProtectedRoute from "./components/protected-route"
 import BookingPage from "./pages/event-booking/booking-page"
 import EventDetailPage from "./pages/event-detail/event-detail-page"
 import EventListPage from "./pages/event-list-page"
+import EventSearchListPage from "./pages/event-search-list-page"
 import HomePage from "./pages/home/home-page"
 import MainEmptyLayout from "./pages/main-empty-layout"
 import MainGrayLayout from "./pages/main-gray-layout"
@@ -41,6 +42,10 @@ const router = createBrowserRouter(
             {
               path: "event/booking/:id",
               Component: BookingPage,
+            },
+            {
+              path: "event/search",
+              Component: EventSearchListPage,
             },
           ],
         },


### PR DESCRIPTION
## ✏️ 작업 개요  
공연 검색 UI/API 연동

## 🔨 작업 내용 상세
- event-search-list-page.tsx 추가

## 🔗 관련 이슈  
- Closes #23 

## ✅ 체크리스트  
- [x] 공연 검색 페이지 구현
- [x] API 연동


## 💬 기타 참고 사항  
- header에 있는 search-bar에 검색할 title 입력 후 enter -> event/search 페이지로 넘어갑니다
