### PR TITLE
[Feature/pyokemon-43] 마이페이지 - 회원 정보 수정 UI/API 연동

### DIFF
--- a/src/api/mypage/fetchers/delete-account.ts
+++ b/src/api/mypage/fetchers/delete-account.ts
@@ -1,0 +1,18 @@
+import { DeleteAccountResponse } from "../../../types/mypage"
+import { accountClient } from "../../client"
+
+export const deleteAccount = async (): Promise<DeleteAccountResponse> => {
+  const accessToken = localStorage.getItem("accessToken")
+
+  if (!accessToken) {
+    throw new Error("Access token not found")
+  }
+
+  const response = await accountClient.delete<DeleteAccountResponse>("/api/users/profile", {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+
+  return response.data
+}

--- a/src/api/mypage/fetchers/put-change-password.ts
+++ b/src/api/mypage/fetchers/put-change-password.ts
@@ -1,0 +1,20 @@
+import { PasswordChangeRequest, PasswordChangeResponse } from "../../../types/mypage"
+import { accountClient } from "../../client"
+
+export const putChangePassword = async (
+  request: PasswordChangeRequest
+): Promise<PasswordChangeResponse> => {
+  const accessToken = localStorage.getItem("accessToken")
+
+  if (!accessToken) {
+    throw new Error("Access token not found")
+  }
+
+  const response = await accountClient.put<PasswordChangeResponse>("/api/password", request, {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  })
+
+  return response.data
+}

--- a/src/components/ui/button/button.tsx
+++ b/src/components/ui/button/button.tsx
@@ -14,20 +14,33 @@ interface ButtonProps {
 // color : 글자 색
 // border button이면 border, borderColor, color 넣어줘야함
 
-const colorMap: Record<string, string> = {
-  primary: "primary",
-  "primary-dark": "primary-dark",
-  white: "white",
-  black: "black",
-  error: "error",
-  "gray-300": "gray-300",
-  "gray-500": "gray-500",
-  "gray-700": "gray-700",
-}
+const getColorStyle = (type: "text" | "bg" | "border", color?: string) => {
+  if (!color) return {}
 
-const getColorClass = (prefix: string, color?: string) => {
-  if (!color || !colorMap[color]) return ""
-  return `${prefix}-${colorMap[color]}`
+  const colorMap: Record<string, string> = {
+    primary: "var(--color-primary)",
+    "primary-dark": "var(--color-primary-dark)",
+    white: "var(--color-white)",
+    black: "var(--color-black)",
+    error: "var(--color-error)",
+    success: "var(--color-success)",
+    "gray-300": "var(--color-gray-300)",
+    "gray-500": "var(--color-gray-500)",
+    "gray-700": "var(--color-gray-700)",
+  }
+
+  const colorValue = colorMap[color]
+  if (!colorValue) return {}
+
+  if (type === "text") {
+    return { color: colorValue }
+  } else if (type === "bg") {
+    return { backgroundColor: colorValue }
+  } else if (type === "border") {
+    return { borderColor: colorValue }
+  }
+
+  return {}
 }
 
 const Button: React.FC<ButtonProps> = ({
@@ -40,22 +53,25 @@ const Button: React.FC<ButtonProps> = ({
   onClick,
   icon,
 }) => {
-  const textColorClass = getColorClass("text", color)
-  const bgColorClass = getColorClass("bg", bgColor)
-  const borderColorClass = getColorClass("border", borderColor)
+  const textStyle = getColorStyle("text", color)
+  const bgStyle = getColorStyle("bg", bgColor)
+  const borderStyle = border
+    ? {
+        border: "1px solid",
+        ...getColorStyle("border", borderColor),
+      }
+    : {}
 
   const baseStyle =
     "rounded-lg h-51 flex justify-center items-center cursor-pointer hover:opacity-80 text-16-semibold "
 
   const sizeStyle = small ? "px-24" : "w-320"
-  const borderStyle = border ? `border-1 ${borderColorClass}` : ""
 
-  const className = [baseStyle, sizeStyle, textColorClass, bgColorClass, borderStyle]
-    .filter(Boolean)
-    .join(" ")
+  const className = [baseStyle, sizeStyle].join(" ")
+  const style = { ...textStyle, ...bgStyle, ...borderStyle }
 
   return (
-    <button className={className} onClick={onClick}>
+    <button className={className} style={style} onClick={onClick}>
       {icon && <span className="mr-6">{icon}</span>}
       {text}
     </button>

--- a/src/pages/mypage/_component/PasswordChangeModal.tsx
+++ b/src/pages/mypage/_component/PasswordChangeModal.tsx
@@ -59,10 +59,10 @@ const PasswordChangeModal: React.FC<PasswordChangeModalProps> = ({ isOpen, onClo
     <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50">
       <div className="shadow-container rounded-lg p-40 w-520 max-w-90vw shadow-xl">
         <div className="flex justify-between items-center mb-32">
-          <h2 className="title-20-bold text-gray-900">비밀번호 수정</h2>
+          <h2 className="title-20-bold text-black">비밀번호 수정</h2>
           <button
             onClick={handleClose}
-            className="w-32 h-32 flex items-center justify-center text-gray-400 hover:text-gray-600 transition-colors"
+            className="w-32 h-32 flex items-center justify-center text-gray-300 hover:text-gray-700 transition-colors"
           >
             <svg className="w-20 h-20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
@@ -82,7 +82,7 @@ const PasswordChangeModal: React.FC<PasswordChangeModalProps> = ({ isOpen, onClo
               type="password"
               value={currentPassword}
               onChange={(e) => setCurrentPassword(e.target.value)}
-              className="w-full p-16 border border-gray-200 rounded-12 text-14 transition-colors focus:border-primary focus:outline-none"
+              className="w-full p-16 border border-gray-300 rounded-12 text-14 transition-colors focus:border-primary focus:outline-none"
               placeholder="현재 비밀번호를 입력하세요"
             />
           </div>
@@ -96,12 +96,12 @@ const PasswordChangeModal: React.FC<PasswordChangeModalProps> = ({ isOpen, onClo
               onFocus={() => setIsNewPasswordFocused(true)}
               className={`w-full p-16 border rounded-12 text-14 transition-colors ${
                 newPasswordError
-                  ? "border-red-500 focus:border-red-500"
-                  : "border-gray-200 focus:border-primary"
+                  ? "border-error focus:border-error"
+                  : "border-gray-300 focus:border-primary"
               } focus:outline-none`}
               placeholder="새 비밀번호를 입력하세요"
             />
-            {newPasswordError && <p className="text-12 text-red-500 mt-8">{newPasswordError}</p>}
+            {newPasswordError && <p className="text-12 text-error mt-8">{newPasswordError}</p>}
           </div>
 
           <div>
@@ -113,14 +113,12 @@ const PasswordChangeModal: React.FC<PasswordChangeModalProps> = ({ isOpen, onClo
               onFocus={() => setIsPasswordCheckFocused(true)}
               className={`w-full p-16 border rounded-12 text-14 transition-colors ${
                 passwordCheckError
-                  ? "border-red-500 focus:border-red-500"
-                  : "border-gray-200 focus:border-primary"
+                  ? "border-error focus:border-error"
+                  : "border-gray-300 focus:border-primary"
               } focus:outline-none`}
               placeholder="비밀번호를 다시 입력하세요"
             />
-            {passwordCheckError && (
-              <p className="text-12 text-red-500 mt-8">{passwordCheckError}</p>
-            )}
+            {passwordCheckError && <p className="text-12 text-error mt-8">{passwordCheckError}</p>}
           </div>
         </div>
 

--- a/src/pages/mypage/_component/PasswordChangeModal.tsx
+++ b/src/pages/mypage/_component/PasswordChangeModal.tsx
@@ -1,0 +1,144 @@
+import React, { useState } from "react"
+
+import Button from "../../../components/ui/button"
+
+interface PasswordChangeModalProps {
+  isOpen: boolean
+  onClose: () => void
+  onSubmit: (currentPassword: string, newPassword: string) => void
+}
+
+const PasswordChangeModal: React.FC<PasswordChangeModalProps> = ({ isOpen, onClose, onSubmit }) => {
+  const [currentPassword, setCurrentPassword] = useState("")
+  const [newPassword, setNewPassword] = useState("")
+  const [passwordCheck, setPasswordCheck] = useState("")
+  const [isNewPasswordFocused, setIsNewPasswordFocused] = useState(false)
+  const [isPasswordCheckFocused, setIsPasswordCheckFocused] = useState(false)
+
+  const resetForm = () => {
+    setCurrentPassword("")
+    setNewPassword("")
+    setPasswordCheck("")
+    setIsNewPasswordFocused(false)
+    setIsPasswordCheckFocused(false)
+  }
+
+  const newPasswordError =
+    !newPassword.trim() && isNewPasswordFocused
+      ? "새 비밀번호는 필수입니다."
+      : !/^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,}$/.test(newPassword) &&
+          newPassword.trim()
+        ? "비밀번호는 8자 이상이며, 영문, 숫자, 특수문자를 포함해야 합니다."
+        : ""
+
+  const passwordCheckError =
+    !passwordCheck.trim() && isPasswordCheckFocused
+      ? "비밀번호 확인은 필수입니다."
+      : passwordCheck && passwordCheck !== newPassword
+        ? "비밀번호가 일치하지 않습니다."
+        : ""
+
+  const isFormValid = !newPasswordError && !passwordCheckError
+
+  const handleSubmit = () => {
+    if (isFormValid) {
+      onSubmit(currentPassword, newPassword)
+      resetForm()
+      onClose()
+    }
+  }
+
+  const handleClose = () => {
+    resetForm()
+    onClose()
+  }
+
+  if (!isOpen) return null
+
+  return (
+    <div className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50">
+      <div className="shadow-container rounded-lg p-40 w-520 max-w-90vw shadow-xl">
+        <div className="flex justify-between items-center mb-32">
+          <h2 className="title-20-bold text-gray-900">비밀번호 수정</h2>
+          <button
+            onClick={handleClose}
+            className="w-32 h-32 flex items-center justify-center text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <svg className="w-20 h-20" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M6 18L18 6M6 6l12 12"
+              />
+            </svg>
+          </button>
+        </div>
+
+        <div className="space-y-24">
+          <div>
+            <label className="block text-14-medium text-gray-700 mb-8">현재 비밀번호</label>
+            <input
+              type="password"
+              value={currentPassword}
+              onChange={(e) => setCurrentPassword(e.target.value)}
+              className="w-full p-16 border border-gray-200 rounded-12 text-14 transition-colors focus:border-primary focus:outline-none"
+              placeholder="현재 비밀번호를 입력하세요"
+            />
+          </div>
+
+          <div>
+            <label className="block text-14-medium text-gray-700 mb-8">새 비밀번호</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              onFocus={() => setIsNewPasswordFocused(true)}
+              className={`w-full p-16 border rounded-12 text-14 transition-colors ${
+                newPasswordError
+                  ? "border-red-500 focus:border-red-500"
+                  : "border-gray-200 focus:border-primary"
+              } focus:outline-none`}
+              placeholder="새 비밀번호를 입력하세요"
+            />
+            {newPasswordError && <p className="text-12 text-red-500 mt-8">{newPasswordError}</p>}
+          </div>
+
+          <div>
+            <label className="block text-14-medium text-gray-700 mb-8">비밀번호 확인</label>
+            <input
+              type="password"
+              value={passwordCheck}
+              onChange={(e) => setPasswordCheck(e.target.value)}
+              onFocus={() => setIsPasswordCheckFocused(true)}
+              className={`w-full p-16 border rounded-12 text-14 transition-colors ${
+                passwordCheckError
+                  ? "border-red-500 focus:border-red-500"
+                  : "border-gray-200 focus:border-primary"
+              } focus:outline-none`}
+              placeholder="비밀번호를 다시 입력하세요"
+            />
+            {passwordCheckError && (
+              <p className="text-12 text-red-500 mt-8">{passwordCheckError}</p>
+            )}
+          </div>
+        </div>
+
+        <div className="flex justify-end space-x-12 mt-40">
+          <Button
+            text="취소"
+            small
+            border
+            borderColor="gray-300"
+            color="gray-700"
+            bgColor="white"
+            onClick={handleClose}
+          />
+          <Button text="완료" small color="white" bgColor="primary" onClick={handleSubmit} />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PasswordChangeModal

--- a/src/pages/mypage/setting-page.tsx
+++ b/src/pages/mypage/setting-page.tsx
@@ -1,0 +1,38 @@
+import Button from "../../components/ui/button"
+
+const SettingPage = () => {
+  return (
+    <div className="px-160 py-64">
+      <p className="title-24-bold">계정 설정</p>
+
+      <div className="mt-48 space-y-32">
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <p className="text-16-bold black mb-8">비밀번호 수정</p>
+            <p className="text-16-medium text-gray-700">비밀번호를 변경할 수 있습니다.</p>
+          </div>
+          <Button
+            text="수정하기"
+            small
+            border
+            borderColor="primary"
+            color="primary"
+            bgColor="white"
+          />
+        </div>
+
+        <div className="h-px bg-gray-300 my-32" />
+
+        <div className="flex items-center justify-between">
+          <div className="flex-1">
+            <p className="text-16-bold black mb-8">회원탈퇴</p>
+            <p className="text-16-medium text-gray-700">계정을 영구적으로 삭제합니다.</p>
+          </div>
+          <Button text="탈퇴하기" small border borderColor="error" color="error" bgColor="white" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SettingPage

--- a/src/pages/mypage/setting-page.tsx
+++ b/src/pages/mypage/setting-page.tsx
@@ -1,12 +1,41 @@
 import React, { useState } from "react"
+import Swal from "sweetalert2"
 
 import Button from "../../components/ui/button"
 import PasswordChangeModal from "./_component/PasswordChangeModal"
 
 const SettingPage = () => {
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
-  const handlePasswordChange = (newPassword: string) => {
+
+  const handlePasswordChange = (currentPassword: string, newPassword: string) => {
+    console.log("현재 비밀번호:", currentPassword)
     console.log("새 비밀번호:", newPassword)
+  }
+
+  const handleWithdraw = () => {
+    Swal.fire({
+      title: "회원탈퇴",
+      text: "정말로 탈퇴하시겠습니까?",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#d33",
+      cancelButtonColor: "#3085d6",
+      confirmButtonText: "탈퇴하기",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        localStorage.clear()
+
+        Swal.fire({
+          title: "탈퇴 완료",
+          text: "회원탈퇴가 완료되었습니다.",
+          icon: "success",
+          confirmButtonText: "확인",
+        }).then(() => {
+          window.location.href = "/"
+        })
+      }
+    })
   }
 
   return (
@@ -37,7 +66,15 @@ const SettingPage = () => {
             <p className="text-16-bold black mb-8">회원탈퇴</p>
             <p className="text-16-medium text-gray-700">계정을 영구적으로 삭제합니다.</p>
           </div>
-          <Button text="탈퇴하기" small border borderColor="error" color="error" bgColor="white" />
+          <Button
+            text="탈퇴하기"
+            small
+            border
+            borderColor="error"
+            color="error"
+            bgColor="white"
+            onClick={handleWithdraw}
+          />
         </div>
       </div>
 

--- a/src/pages/mypage/setting-page.tsx
+++ b/src/pages/mypage/setting-page.tsx
@@ -1,8 +1,16 @@
+import React, { useState } from "react"
+
 import Button from "../../components/ui/button"
+import PasswordChangeModal from "./_component/PasswordChangeModal"
 
 const SettingPage = () => {
+  const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
+  const handlePasswordChange = (newPassword: string) => {
+    console.log("새 비밀번호:", newPassword)
+  }
+
   return (
-    <div className="px-160 py-64">
+    <div className="px-160 py-64 relative">
       <p className="title-24-bold">계정 설정</p>
 
       <div className="mt-48 space-y-32">
@@ -18,6 +26,7 @@ const SettingPage = () => {
             borderColor="primary"
             color="primary"
             bgColor="white"
+            onClick={() => setIsPasswordModalOpen(true)}
           />
         </div>
 
@@ -31,6 +40,12 @@ const SettingPage = () => {
           <Button text="탈퇴하기" small border borderColor="error" color="error" bgColor="white" />
         </div>
       </div>
+
+      <PasswordChangeModal
+        isOpen={isPasswordModalOpen}
+        onClose={() => setIsPasswordModalOpen(false)}
+        onSubmit={handlePasswordChange}
+      />
     </div>
   )
 }

--- a/src/pages/mypage/setting-page.tsx
+++ b/src/pages/mypage/setting-page.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { deleteAccount } from "@/api/mypage/fetchers/delete-account"
 import { putChangePassword } from "@/api/mypage/fetchers/put-change-password"
 import Swal from "sweetalert2"
 
@@ -35,8 +36,8 @@ const SettingPage = () => {
     }
   }
 
-  const handleWithdraw = () => {
-    Swal.fire({
+  const handleWithdraw = async () => {
+    const result = await Swal.fire({
       title: "회원탈퇴",
       text: "정말로 탈퇴하시겠습니까?",
       icon: "warning",
@@ -45,20 +46,32 @@ const SettingPage = () => {
       cancelButtonColor: "#3085d6",
       confirmButtonText: "탈퇴하기",
       cancelButtonText: "취소",
-    }).then((result) => {
-      if (result.isConfirmed) {
+    })
+
+    if (result.isConfirmed) {
+      try {
+        await deleteAccount()
         localStorage.clear()
 
-        Swal.fire({
+        await Swal.fire({
           title: "탈퇴 완료",
           text: "회원탈퇴가 완료되었습니다.",
           icon: "success",
           confirmButtonText: "확인",
-        }).then(() => {
-          window.location.href = "/"
+        })
+
+        window.location.href = "/"
+      } catch (error) {
+        console.error("회원탈퇴 실패:", error)
+
+        Swal.fire({
+          title: "오류",
+          text: "회원탈퇴에 실패했습니다. 다시 시도해주세요.",
+          icon: "error",
+          confirmButtonText: "확인",
         })
       }
-    })
+    }
   }
 
   return (

--- a/src/pages/mypage/setting-page.tsx
+++ b/src/pages/mypage/setting-page.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react"
+import { putChangePassword } from "@/api/mypage/fetchers/put-change-password"
 import Swal from "sweetalert2"
 
 import Button from "../../components/ui/button"
@@ -7,9 +8,31 @@ import PasswordChangeModal from "./_component/PasswordChangeModal"
 const SettingPage = () => {
   const [isPasswordModalOpen, setIsPasswordModalOpen] = useState(false)
 
-  const handlePasswordChange = (currentPassword: string, newPassword: string) => {
-    console.log("현재 비밀번호:", currentPassword)
-    console.log("새 비밀번호:", newPassword)
+  const handlePasswordChange = async (currentPassword: string, newPassword: string) => {
+    try {
+      await putChangePassword({
+        currentPassword,
+        newPassword,
+      })
+
+      Swal.fire({
+        title: "성공",
+        text: "비밀번호가 성공적으로 변경되었습니다.",
+        icon: "success",
+        confirmButtonText: "확인",
+      })
+
+      setIsPasswordModalOpen(false)
+    } catch (error) {
+      console.error("비밀번호 변경 실패:", error)
+
+      Swal.fire({
+        title: "오류",
+        text: "비밀번호 변경에 실패했습니다. 다시 시도해주세요.",
+        icon: "error",
+        confirmButtonText: "확인",
+      })
+    }
   }
 
   const handleWithdraw = () => {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -11,6 +11,7 @@ import HomePage from "./pages/home/home-page"
 import MainEmptyLayout from "./pages/main-empty-layout"
 import MainGrayLayout from "./pages/main-gray-layout"
 import MainContainerLayout from "./pages/main-layout"
+import SettingPage from "./pages/mypage/setting-page"
 import RootLayout from "./pages/root-layout"
 
 const router = createBrowserRouter(
@@ -46,6 +47,10 @@ const router = createBrowserRouter(
             {
               path: "event/search",
               Component: EventSearchListPage,
+            },
+            {
+              path: "mypage/setting",
+              Component: SettingPage,
             },
           ],
         },

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -9,3 +9,10 @@ export interface PasswordChangeResponse {
   data: null
   errorCode: string | null
 }
+
+export interface DeleteAccountResponse {
+  success: boolean
+  message: string
+  data: null
+  errorCode: string | null
+}

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -1,0 +1,11 @@
+export interface PasswordChangeRequest {
+  currentPassword: string
+  newPassword: string
+}
+
+export interface PasswordChangeResponse {
+  success: boolean
+  message: string
+  data: null
+  errorCode: string | null
+}


### PR DESCRIPTION
## ✏️ 작업 개요  
마이페이지에서 회원정보 수정 UI/API 연동

## 🔨 작업 내용 상세
<img width="1651" height="460" alt="image" src="https://github.com/user-attachments/assets/eb9d5f16-9799-4e6f-879e-9cd6e87d9306" />

- 비밀번호 수정 -> 모달창
<img width="253" height="283" alt="image" src="https://github.com/user-attachments/assets/4f519452-97fb-4f4a-b4d7-012fd195d0d2" />
<img width="283" height="273" alt="image" src="https://github.com/user-attachments/assets/f104049d-dea2-42a1-a804-525d470909f1" />

- 회원 탈퇴
<img width="242" height="177" alt="image" src="https://github.com/user-attachments/assets/4747ef40-a803-408f-8393-0478759ccb12" />


## 🔗 관련 이슈  
- Closes #25 

## ✅ 체크리스트  
- [x] 비밀번호 수정 모달 UI 구현
- [x] 비밀번호 유효성 검증 로직 구현
- [x] 비밀번호 변경 API 연동 (PUT /api/password)
- [x] 회원탈퇴 UI 구현
- [x] 회원탈퇴 API 연동 (DELETE /api/users/profile)
- [x] 로컬스토리지 관리 (탈퇴 시 전체 삭제)

## 💬 기타 참고 사항  
- Bearer Token 담아야해서 로컬스토리지에 axxessToken 없으면 오류나요~!
- button component 수정했어요 -> 오류나면 바꿔주세요~~
