### PR TITLE
Feature/#28/pyokemon 78 관심 공연 api 연동

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-  <link href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
-    rel="stylesheet" />
+    <link
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
+      rel="stylesheet" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Pyokemon Web</title>
 </head>

--- a/src/api/event/fetchers/post-saved-event.ts
+++ b/src/api/event/fetchers/post-saved-event.ts
@@ -1,10 +1,10 @@
-import { eventClient } from "../../client"
+import { eventClient } from "@/api/client"
 
-export const fetchEventDetail = async (eventId: number) => {
+export const postSavedEvent = async (eventId: number) => {
   try {
     // 테스트용 헤더 설정
     eventClient.defaults.headers.common["X-Auth-AccountId"] = "1"
-    const res = await eventClient.get(`/api/events/${eventId}`)
+    const res = await eventClient.post(`/api/events/save/${eventId}`)
     console.log(res.data)
 
     return res.data

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,10 @@
 @import 'swiper/css';
 @import 'swiper/css/pagination';
 
+:root {
+  font-family: Pretendard;
+}
+
 body {
   margin: 0;
   color: var(--color-black);

--- a/src/pages/event-detail/event-detail-page.tsx
+++ b/src/pages/event-detail/event-detail-page.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from "react"
 import { useGetEventBookingQuery } from "@/api/booking/queries/use-get-event-booking-query"
+import { postSavedEvent } from "@/api/event/fetchers/post-saved-event"
 import { useGetEventDetailQuery } from "@/api/event/queries/use-get-event-detail-query"
 import { useEventStore } from "@/store/event/event-store"
 import { format } from "date-fns"
@@ -22,6 +23,7 @@ const EventDetailPage = () => {
 
   const handleMarkClick = () => {
     setIsMarked(!isMarked)
+    postSavedEvent(Number(eventId))
   }
   const { data: event, isLoading } = useGetEventDetailQuery(Number(eventId))
   const { data: booking } = useGetEventBookingQuery(event?.eventScheduleId ?? 1)

--- a/src/pages/event-detail/event-detail-page.tsx
+++ b/src/pages/event-detail/event-detail-page.tsx
@@ -18,7 +18,7 @@ interface SeatPrice {
 const EventDetailPage = () => {
   const navigate = useNavigate()
   const { eventId } = useParams()
-  const [isMarked, setIsMarked] = useState(true)
+  const [isMarked, setIsMarked] = useState<boolean | null>(null)
 
   const handleMarkClick = () => {
     setIsMarked(!isMarked)
@@ -31,6 +31,7 @@ const EventDetailPage = () => {
 
   useEffect(() => {
     if (event) {
+      setIsMarked(event.saved ?? false)
       setEvent(event)
     }
   }, [event, setEvent])

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -11,4 +11,5 @@ export interface EventType {
   eventScheduleId: number
   venueId?: number
   total?: number
+  saved?: boolean
 }


### PR DESCRIPTION
## ✏️ 작업 개요  
이번 PR에서 작업한 내용을 간단히 요약해주세요.

## 🔨 작업 내용 상세
- 관심 공연 등록, 취소 api 연동
- 상세 정보에서 관심 공연 여부 받아오기

## 🔗 관련 이슈  
- Closes #이슈번호
- #28 

## ✅ 체크리스트  



## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
- 공연 상세 정보 조회 페이지에서 관심 공연 버튼 클릭 시 관심 공연 등록됩니다
- 이미 관심 공연이면 삭제됩니다
