### PR TITLE
Feature/pyokemon 139 예매 tenant

### DIFF
--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useCallback, useRef, useState } from "react"
 import { IoNotificationsOutline, IoPersonOutline, IoSearchOutline } from "react-icons/io5"
 import { Link, useLocation, useNavigate } from "react-router"
 
@@ -22,6 +22,7 @@ function Header() {
   const navigate = useNavigate()
   const [showNotification, setShowNotification] = useState(false)
   const [showMyPageModal, setShowMyPageModal] = useState(false)
+  const searchBarRef = useRef<HTMLDivElement>(null)
 
   const handleClickMyPage = () => {
     const accessToken = localStorage.getItem("accessToken")
@@ -37,6 +38,24 @@ function Header() {
       navigate(`/event/search?keyword=${keyword}`)
     }
   }
+
+  const handleClickOutside = useCallback((event: MouseEvent) => {
+    if (searchBarRef.current && !searchBarRef.current.contains(event.target as Node)) {
+      setShowSearchBar(false)
+    }
+  }, [])
+
+  const handleSearchIconClick = useCallback(() => {
+    const newShowSearchBar = !showSearchBar
+    setShowSearchBar(newShowSearchBar)
+
+    if (newShowSearchBar) {
+      document.addEventListener("mousedown", handleClickOutside)
+    } else {
+      document.removeEventListener("mousedown", handleClickOutside)
+    }
+  }, [showSearchBar, handleClickOutside])
+
   return (
     <div className="flex bg-white h-100 w-full text-black items-center justify-between px-160 shadow-container">
       <Link to="/">
@@ -60,6 +79,7 @@ function Header() {
 
           {/* search bar */}
           <div
+            ref={searchBarRef}
             className="h-36 flex items-center border-black border-1 px-16 rounded-full justify-between transition-all duration-300 ease-in-out overflow-hidden"
             style={{
               opacity: showSearchBar ? 1 : 0,
@@ -85,7 +105,7 @@ function Header() {
 
           {/* icons */}
           <ul className="flex gap-16 relative">
-            <li className={listStyle} onClick={() => setShowSearchBar(!showSearchBar)}>
+            <li className={listStyle} onClick={handleSearchIconClick}>
               <IoSearchOutline className={iconStyle} />
             </li>
             <li className={listStyle} onClick={() => setShowNotification(!showNotification)}>

--- a/src/components/header/header.tsx
+++ b/src/components/header/header.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react"
+import { useState } from "react"
 import { IoNotificationsOutline, IoPersonOutline, IoSearchOutline } from "react-icons/io5"
 import { Link, useLocation, useNavigate } from "react-router"
 
@@ -22,7 +22,6 @@ function Header() {
   const navigate = useNavigate()
   const [showNotification, setShowNotification] = useState(false)
   const [showMyPageModal, setShowMyPageModal] = useState(false)
-  const searchBarRef = useRef<HTMLDivElement>(null)
 
   const handleClickMyPage = () => {
     const accessToken = localStorage.getItem("accessToken")
@@ -38,24 +37,6 @@ function Header() {
       navigate(`/event/search?keyword=${keyword}`)
     }
   }
-
-  const handleClickOutside = useCallback((event: MouseEvent) => {
-    if (searchBarRef.current && !searchBarRef.current.contains(event.target as Node)) {
-      setShowSearchBar(false)
-    }
-  }, [])
-
-  const handleSearchIconClick = useCallback(() => {
-    const newShowSearchBar = !showSearchBar
-    setShowSearchBar(newShowSearchBar)
-
-    if (newShowSearchBar) {
-      document.addEventListener("mousedown", handleClickOutside)
-    } else {
-      document.removeEventListener("mousedown", handleClickOutside)
-    }
-  }, [showSearchBar, handleClickOutside])
-
   return (
     <div className="flex bg-white h-100 w-full text-black items-center justify-between px-160 shadow-container">
       <Link to="/">
@@ -79,7 +60,6 @@ function Header() {
 
           {/* search bar */}
           <div
-            ref={searchBarRef}
             className="h-36 flex items-center border-black border-1 px-16 rounded-full justify-between transition-all duration-300 ease-in-out overflow-hidden"
             style={{
               opacity: showSearchBar ? 1 : 0,
@@ -105,7 +85,7 @@ function Header() {
 
           {/* icons */}
           <ul className="flex gap-16 relative">
-            <li className={listStyle} onClick={handleSearchIconClick}>
+            <li className={listStyle} onClick={() => setShowSearchBar(!showSearchBar)}>
               <IoSearchOutline className={iconStyle} />
             </li>
             <li className={listStyle} onClick={() => setShowNotification(!showNotification)}>

--- a/src/pages/event-booking/booking-page.tsx
+++ b/src/pages/event-booking/booking-page.tsx
@@ -10,6 +10,7 @@ import {
   useGetSeatClassQuery,
 } from "../../api/booking/queries/use-get-event-booking-query"
 import { usePostEventBookingQuery } from "../../api/booking/queries/use-post-event-booking-query"
+import { useEventStore } from "../../store/event/event-store"
 import { Seat_class } from "../../types/booking"
 import LoadingPage from "../loading-page"
 import BookingSidebar from "./_component/booking_sidebar"
@@ -19,6 +20,7 @@ import SeatingChart from "./_component/seating_chart"
 const BookingPage = () => {
   const { id } = useParams()
   const eventId = id || ""
+  const { event } = useEventStore()
   const [selectedGrade, setSelectedGrade] = useState<string>("")
   const [selectedSeat, setSelectedSeat] = useState<Seat_class | null>(null)
   const [isPaymentLoading, setIsLoading] = useState(false)
@@ -50,22 +52,22 @@ const BookingPage = () => {
     return gradeInfo?.price || 0
   }
 
-  interface PaymentRequest {
-    bookingId: number
-    orderId: string
-    amount: number
-    method: string
-    accountId: number
-  }
+  // interface PaymentRequest {
+  //   bookingId: number
+  //   orderId: string
+  //   amount: number
+  //   method: string
+  //   accountId: number
+  // }
 
-  interface PaymentResponse {
-    orderId: string
-    amount: number
-  }
+  // interface PaymentResponse {
+  //   orderId: string
+  //   amount: number
+  // }
 
-  const mutateAsync = async (data: PaymentRequest): Promise<PaymentResponse> => {
-    return { orderId: data.orderId, amount: data.amount }
-  }
+  // const mutateAsync = async (data: PaymentRequest): Promise<PaymentResponse> => {
+  //   return { orderId: data.orderId, amount: data.amount }
+  // }
 
   const handlePaymentClick = async () => {
     if (isPaymentLoading) return
@@ -74,6 +76,17 @@ const BookingPage = () => {
       Swal.fire({
         icon: "warning",
         title: "좌석을 선택해주세요!",
+        confirmButtonText: "확인",
+        confirmButtonColor: "var(--color-primary)",
+      })
+      setIsLoading(false)
+      return
+    }
+    if (!event?.tenantId) {
+      Swal.fire({
+        icon: "error",
+        title: "예매 정보를 불러올 수 없습니다.",
+        text: "이전 페이지로 돌아가서 다시 시도해주세요.",
         confirmButtonText: "확인",
         confirmButtonColor: "var(--color-primary)",
       })
@@ -105,6 +118,7 @@ const BookingPage = () => {
         {
           eventScheduleId: Number(eventId),
           seatId: selectedSeat.seatId,
+          tenantId: Number(event.tenantId),
         },
         {
           onSuccess: async (bookingResponse) => {
@@ -142,16 +156,7 @@ const BookingPage = () => {
 
   const isLoading = isBookingLoading || (selectedGrade && isSeatsLoading) || isBookingPending
   if (isLoading) {
-    return (
-      // <div className="min-h-screen bg-l text-white">
-      //   <Header />
-      //   <main className="flex items-center justify-center min-h-[calc(100vh-280px)]">
-      //     <div className="text-xl">로딩 중...</div>
-      //   </main>
-      //   <Footer />
-      // </div>
-      <LoadingPage />
-    )
+    return <LoadingPage />
   }
 
   return (

--- a/src/pages/event-detail/event-detail-page.tsx
+++ b/src/pages/event-detail/event-detail-page.tsx
@@ -59,7 +59,7 @@ const EventDetailPage = () => {
 
   return (
     <div className="px-160 py-64">
-      <section className="flex gap-60 mb-60 justify-center">
+      <section className="flex gap-100 mb-60 justify-center">
         <article>
           <img
             src={event.thumbnailUrl}

--- a/src/pages/event-search-list-page.tsx
+++ b/src/pages/event-search-list-page.tsx
@@ -46,13 +46,6 @@ const EventSearchListPage = () => {
 
   if (isLoading || !eventList) return <LoadingPage />
   if (error) return <ErrorPage />
-  if (eventList.length === 0) {
-    return (
-      <div className="px-160 mb-48">
-        <p className="text-center py-48">검색 결과가 없습니다.</p>
-      </div>
-    )
-  }
 
   return (
     <div className="px-160 mb-48">
@@ -71,20 +64,26 @@ const EventSearchListPage = () => {
       </ul>
 
       {/* event */}
-      <div className="grid grid-cols-3 gap-24">
-        {eventList.map((event, i) => {
-          return <EventPreviewCard key={i} event={event} />
-        })}
-      </div>
+      {eventList.length === 0 ? (
+        <p className="text-center py-48">검색 결과가 없습니다.</p>
+      ) : (
+        <>
+          <div className="grid grid-cols-3 gap-24">
+            {eventList.map((event, i) => {
+              return <EventPreviewCard key={i} event={event} />
+            })}
+          </div>
 
-      <div className="flex justify-center mt-12">
-        <Pagination
-          current={page}
-          total={eventList[0]?.total ?? 0}
-          pageSize={9}
-          onChange={(p) => handlePageChange(p)}
-        />
-      </div>
+          <div className="flex justify-center mt-12">
+            <Pagination
+              current={page}
+              total={eventList[0]?.total ?? 0}
+              pageSize={9}
+              onChange={(p) => handlePageChange(p)}
+            />
+          </div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/pages/home/_component/banner/banner.tsx
+++ b/src/pages/home/_component/banner/banner.tsx
@@ -36,7 +36,7 @@ const Banner = () => {
 
   return (
     <div className="w-full">
-      <div className="relative w-full h-600 overflow-hidden">
+      <div className="relative w-full overflow-hidden">
         <Swiper
           modules={[Autoplay, Pagination]}
           loop={true}
@@ -44,14 +44,14 @@ const Banner = () => {
           pagination={{ el: ".banner-pagination", clickable: true }}
           onSwiper={setSwiperInstance}
           onSlideChange={handleSlideChange}
-          className="w-full h-full"
+          className="w-full"
         >
           {bannerData.map((banner) => (
             <SwiperSlide key={banner.id}>
               <img
                 src={banner.image}
                 alt={`Banner ${banner.id}`}
-                className="w-full h-full object-cover"
+                className="w-full h-auto object-cover"
               />
             </SwiperSlide>
           ))}
@@ -59,7 +59,7 @@ const Banner = () => {
 
         <div className="banner-pagination absolute bottom-6 left-1/2 transform -translate-x-1/2 flex space-x-3" />
 
-        <div className="absolute bottom-8 left-1/2 transform -translate-x-1/2 flex justify-center space-x-4 px-4 z-10">
+        <div className="absolute bottom-30 left-1/2 transform -translate-x-1/2 flex justify-center space-x-10 px-4 z-10">
           {bannerData.map((banner, index) => (
             <div
               key={banner.id}

--- a/src/pages/login-page.tsx
+++ b/src/pages/login-page.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react"
+import { useCallback, useState } from "react"
 import { useMutation } from "@tanstack/react-query"
 import { useNavigate } from "react-router"
 
@@ -34,7 +34,7 @@ const LoginPage = () => {
     },
   })
 
-  const handleLogin = () => {
+  const handleLogin = useCallback(() => {
     if (!loginId || !password) {
       alert("아이디와 비밀번호를 입력해주세요.")
       return
@@ -44,7 +44,16 @@ const LoginPage = () => {
       loginId,
       password,
     })
-  }
+  }, [loginId, password, loginMutation])
+
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Enter") {
+        handleLogin()
+      }
+    },
+    [handleLogin]
+  )
 
   const handleSignupClick = () => {
     navigate(`/signup`)
@@ -55,7 +64,7 @@ const LoginPage = () => {
       <div className="w-392 h-480 bg-white rounded-lg shadow-container flex flex-col items-center justify-center">
         <img src={login} alt="login" className="h-24 mb-60 mt-60" />
 
-        <div className="flex flex-col gap-16 mb-24">
+        <div className="flex flex-col gap-16 mb-24" onKeyDown={handleKeyDown} tabIndex={0}>
           <Input placeholder="아이디" value={loginId} onChange={setLoginId} type="text" />
           <Input placeholder="비밀번호" value={password} onChange={setPassword} type="password" />
         </div>

--- a/src/pages/signup-page.tsx
+++ b/src/pages/signup-page.tsx
@@ -26,6 +26,15 @@ function formatPhoneNumber(value: string): string {
   return `${numbers.slice(0, 3)}-${numbers.slice(3, 7)}-${numbers.slice(7, 11)}`
 }
 
+function formatBirthDate(value: string): string {
+  const numbers = value.replace(/[^\d]/g, "")
+  if (numbers.length <= 4) return numbers
+  if (numbers.length <= 6) return `${numbers.slice(0, 4)}-${numbers.slice(4)}`
+  if (numbers.length <= 8)
+    return `${numbers.slice(0, 4)}-${numbers.slice(4, 6)}-${numbers.slice(6, 8)}`
+  return `${numbers.slice(0, 4)}-${numbers.slice(4, 6)}-${numbers.slice(6, 8)}`
+}
+
 function validateField(fieldName: keyof SignUpForm, value: string, form?: SignUpForm): string {
   switch (fieldName) {
     case "loginId":
@@ -81,6 +90,9 @@ function SignUpPage() {
       if (fieldName === "phone") {
         finalValue = formatPhoneNumber(value)
       }
+      if (fieldName === "birth") {
+        finalValue = formatBirthDate(value)
+      }
 
       setForm((prev) => ({ ...prev, [fieldName]: finalValue }))
       const error = validateField(fieldName, finalValue, { ...form, [fieldName]: finalValue })
@@ -131,12 +143,21 @@ function SignUpPage() {
     }
   }, [form, navigate])
 
+  const handleKeyDown = useCallback(
+    (event: React.KeyboardEvent) => {
+      if (event.key === "Enter") {
+        handleSignUp()
+      }
+    },
+    [handleSignUp]
+  )
+
   return (
     <div className="min-h-screen flex items-center justify-center">
       <div className="w-392 h-700 bg-white rounded-lg shadow-container flex flex-col items-center justify-center p-32">
         <img src={signup} alt="signup" className="h-24 mb-40 mt-40" />
 
-        <div className="flex flex-col gap-16 mb-24 w-full">
+        <div className="flex flex-col gap-16 mb-24 w-full" onKeyDown={handleKeyDown} tabIndex={0}>
           <div>
             <Input
               placeholder="아이디"
@@ -201,7 +222,7 @@ function SignUpPage() {
               placeholder="생년월일"
               value={form.birth}
               onChange={(value) => handleFieldChange("birth", value)}
-              type="date"
+              type="text"
               error={!!errors.birth}
             />
             {errors.birth && <p className="text-error text-12-regular mt-4">{errors.birth}</p>}

--- a/src/types/booking.ts
+++ b/src/types/booking.ts
@@ -18,6 +18,7 @@ export interface Seat_class {
 export interface PostEventBookingRequest {
   eventScheduleId: number
   seatId: number
+  tenantId: number
 }
 
 export interface PostEventBookingResponse {


### PR DESCRIPTION
## ✏️ 작업 개요  
잡다한 수정.. 자잘해서 지라랑 브랜치 파기 귀찮았어요ㅠ

## 🔨 작업 내용 상세
- 결제하기 누르면 booking에 tenantId도 같이 보내기
- signup-page: 생년월일 format 수정
- login/signup에서 enter 누르면 버튼 눌리게
- event-datail-page: gap 넓히기
- banner: w-full/h-auto로 고정크기 변경
- event-search-list-page: 검색 결과 없어도 장르탭바 고정되게

## 🔗 관련 이슈  
- Closes #48 

## ✅ 체크리스트  
- [x] pnpm build 잘 됨

## 💬 기타 참고 사항  
- 
