### PR TITLE
[Feature/pyokemon-156] 예매취소 api 연동

### DIFF
--- a/src/api/booking/fetchers/delete-event-booking.ts
+++ b/src/api/booking/fetchers/delete-event-booking.ts
@@ -1,0 +1,18 @@
+import { bookingClient, setAuthorizationHeader } from "@/api/client"
+
+export const deleteBookiing = async (eventScheduleId: number) => {
+  const accessToken = localStorage.getItem("accessToken")
+
+  if (!accessToken) {
+    throw new Error("Access token not found")
+  }
+
+  try {
+    setAuthorizationHeader(accessToken)
+    const response = await bookingClient.delete(`/api/bookings/booking/${eventScheduleId}`)
+    return response.data
+  } catch (error) {
+    console.error("Failed to fetch booking data:", error)
+    throw error
+  }
+}

--- a/src/api/booking/queries/use-delete-event-booking-query.ts
+++ b/src/api/booking/queries/use-delete-event-booking-query.ts
@@ -1,0 +1,16 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query"
+
+import { deleteBookiing } from "../fetchers/delete-event-booking"
+
+export const useDeleteEventBookingQuery = () => {
+  const queryClient = useQueryClient()
+
+  return useMutation({
+    mutationFn: (eventScheduleId: number) => deleteBookiing(eventScheduleId),
+    onSuccess: () => {
+      // 예매 목록과 예매 상세 정보를 무효화하여 최신 데이터를 가져오도록 함
+      queryClient.invalidateQueries({ queryKey: ["myBookings"] })
+      queryClient.invalidateQueries({ queryKey: ["bookingDetail"] })
+    },
+  })
+}

--- a/src/pages/mypage/booking-detail-page.tsx
+++ b/src/pages/mypage/booking-detail-page.tsx
@@ -1,10 +1,12 @@
 import React from "react"
+import { useDeleteEventBookingQuery } from "@/api/booking/queries/use-delete-event-booking-query"
 import { useGetBookingDetailQuery } from "@/api/mypage/queries/use-get-booking-detail-query"
 import { mapTicketDetailToTicket } from "@/utils/map-ticket"
 import { format } from "date-fns"
 import { ko } from "date-fns/locale"
 import { IoChevronBackOutline } from "react-icons/io5"
 import { useNavigate, useParams } from "react-router"
+import Swal from "sweetalert2"
 
 import Button from "@/components/ui/button"
 import TicketCard from "@/components/ticket-card/ticket-card"
@@ -17,6 +19,56 @@ const BookingDetailPage = () => {
   const navigate = useNavigate()
 
   const { data, isLoading, error } = useGetBookingDetailQuery(Number(bookingId))
+  const { mutate: deleteBooking, isPending: isDeleting } = useDeleteEventBookingQuery()
+
+  const handleDeleteBooking = () => {
+    console.log("예매 상세 데이터:", data)
+    console.log("eventScheduleId:", data?.event?.eventScheduleId)
+
+    if (!data?.event?.eventScheduleId) {
+      Swal.fire({
+        icon: "error",
+        title: "오류",
+        text: "예매 정보를 찾을 수 없습니다.",
+        confirmButtonText: "확인",
+      })
+      return
+    }
+
+    Swal.fire({
+      title: "예매 취소",
+      text: "정말로 예매를 취소하시겠습니까?",
+      icon: "warning",
+      showCancelButton: true,
+      confirmButtonColor: "#d33",
+      cancelButtonColor: "#3085d6",
+      confirmButtonText: "예매 취소",
+      cancelButtonText: "취소",
+    }).then((result) => {
+      if (result.isConfirmed) {
+        deleteBooking(data.event.eventScheduleId, {
+          onSuccess: () => {
+            Swal.fire({
+              icon: "success",
+              title: "예매 취소 완료",
+              text: "예매가 성공적으로 취소되었습니다.",
+              confirmButtonText: "확인",
+            }).then(() => {
+              navigate(-1)
+            })
+          },
+          onError: () => {
+            Swal.fire({
+              icon: "error",
+              title: "예매 취소 실패",
+              text: "예매 취소에 실패했습니다. 다시 시도해주세요.",
+              confirmButtonText: "확인",
+            })
+          },
+        })
+      }
+    })
+  }
 
   if (isLoading || !data) {
     return <LoadingPage />
@@ -25,6 +77,8 @@ const BookingDetailPage = () => {
   if (error) {
     return <ErrorPage />
   }
+
+  const isBookingCancelled = data.status === "예약 취소"
 
   const labelStyle = "text-16-medium text-gray-700 w-100"
   const valueStyle = "text-16-medium text-black"
@@ -87,7 +141,14 @@ const BookingDetailPage = () => {
                 </li>
               ))}
             </ul>
-            <Button border borderColor="error" text="예매 취소" bgColor="white" color="error" />
+            <Button
+              border
+              borderColor={isBookingCancelled ? "gray-500" : "error"}
+              text={isDeleting ? "취소 중..." : isBookingCancelled ? "예매 취소됨" : "예매 취소"}
+              bgColor="white"
+              color={isBookingCancelled ? "gray-500" : "error"}
+              onClick={isBookingCancelled ? undefined : handleDeleteBooking}
+            />
           </div>
         </div>
       </div>


### PR DESCRIPTION
## ✏️ 작업 개요  
mypage에서 예매내역 확인 중 예매취소 버튼 누르면 예매 취소하기

## 🔨 작업 내용 상세
- 예매 취소 api 파일 -> `src/api/booking/fetchers/delete-event-booking.ts` / `src/api/booking/queries/use-delete-event-booking-query.ts`
- status가 예매완료일때만 예매취소 활성화
- 예매취소시 api 요청 후 kafka까지 확인 완료

## 🔗 관련 이슈  
- Closes #54 

## ✅ 체크리스트  
- [ ] 테스트 코드 작성 완료
- [ ] 로컬에서 기능 정상 작동 확인
- [ ] Swagger UI에서 API 확인 완료
- [ ] 예외 처리 및 ResponseDto 적용
- [ ] 공통 모듈(공통 DTO, Exception 등) 사용 지침 준수
- [ ] Google Java Style Guide 및 네이밍 규칙 준수
- [ ] Flyway 마이그레이션 파일 작성 (필요 시)


## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
