### PR TITLE
Feature/#57/pyokemon 159 예매 내역 조회 페이징

### DIFF
--- a/src/api/mypage/fetchers/get-my-bookings.ts
+++ b/src/api/mypage/fetchers/get-my-bookings.ts
@@ -1,6 +1,6 @@
 import { bffClient, setAuthorizationHeader } from "@/api/client/base-client"
 
-export const fetchMyBooking = async () => {
+export const fetchMyBooking = async (page: number = 0, size: number = 10) => {
   const accessToken = localStorage.getItem("accessToken")
 
   if (!accessToken) {
@@ -9,7 +9,9 @@ export const fetchMyBooking = async () => {
 
   try {
     setAuthorizationHeader(accessToken)
-    const res = await bffClient.get(`/api/mypage/bookings`)
+    const res = await bffClient.get(`/api/mypage/bookings`, {
+      params: { page, size },
+    })
     console.log(res.data)
     return res.data
   } catch (error) {

--- a/src/api/mypage/queries/use-get-my-bookings-query.ts
+++ b/src/api/mypage/queries/use-get-my-bookings-query.ts
@@ -2,9 +2,9 @@ import { useQuery } from "@tanstack/react-query"
 
 import { fetchMyBooking } from "../fetchers/get-my-bookings"
 
-export const useGetMyBookingsQuery = () => {
+export const useGetMyBookingsQuery = (page?: number, size?: number) => {
   return useQuery({
     queryKey: ["myBookings"],
-    queryFn: () => fetchMyBooking(),
+    queryFn: () => fetchMyBooking(page, size),
   })
 }

--- a/src/components/ticket-card/ticket-card.tsx
+++ b/src/components/ticket-card/ticket-card.tsx
@@ -9,6 +9,7 @@ interface TicketCardProps {
 }
 
 const TicketCard: React.FC<TicketCardProps> = ({ ticket }) => {
+  const statusStyle = ticket.status === "예약 취소" ? "text-error" : "text-primary"
   return (
     <div className="shadow-container w-full p-24 bg-white rounded-lg h-200">
       <div className="flex justify-between h-full">
@@ -29,7 +30,7 @@ const TicketCard: React.FC<TicketCardProps> = ({ ticket }) => {
         </div>
 
         <div className="flex flex-col justify-between text-end">
-          <p className="text-16-medium text-primary">{ticket.status}</p>
+          <p className={`text-16-medium ${statusStyle}`}>{ticket.status}</p>
           <p className="title-18-bold truncate">{ticket.totalPrice.toLocaleString()}원</p>
         </div>
       </div>

--- a/src/pages/mypage/my-bookings-page.tsx
+++ b/src/pages/mypage/my-bookings-page.tsx
@@ -3,6 +3,7 @@ import { useGetMyBookingsQuery } from "@/api/mypage/queries/use-get-my-bookings-
 import { useNavigate, useSearchParams } from "react-router"
 
 import { Ticket } from "@/types/ticket"
+import Button from "@/components/ui/button"
 import Pagination from "@/components/ui/pagination"
 import TicketCard from "@/components/ticket-card/ticket-card"
 
@@ -24,7 +25,25 @@ const MyBookingsPage = () => {
     setSearchParams({ page: newPage.toString() })
   }
 
-  if (isLoading || !data) {
+  if (!data || data === "") {
+    return (
+      <div className="px-160 mb-48">
+        <h1 className="title-24-bold pt-48">내 예매 내역</h1>
+        <p className="text-center py-120 text-gray-500">예매 내역이 없습니다.</p>
+        <div className="w-full flex justify-center items-center">
+          <Button
+            text="공연 예매하러 가기"
+            border
+            borderColor="primary"
+            bgColor="white"
+            color="primary"
+            onClick={() => navigate("/event")}
+          />
+        </div>
+      </div>
+    )
+  }
+  if (isLoading) {
     return <LoadingPage />
   }
 

--- a/src/pages/mypage/my-bookings-page.tsx
+++ b/src/pages/mypage/my-bookings-page.tsx
@@ -1,8 +1,9 @@
 import React from "react"
 import { useGetMyBookingsQuery } from "@/api/mypage/queries/use-get-my-bookings-query"
-import { useNavigate } from "react-router"
+import { useNavigate, useSearchParams } from "react-router"
 
 import { Ticket } from "@/types/ticket"
+import Pagination from "@/components/ui/pagination"
 import TicketCard from "@/components/ticket-card/ticket-card"
 
 import ErrorPage from "../error-page"
@@ -10,11 +11,17 @@ import LoadingPage from "../loading-page"
 
 const MyBookingsPage = () => {
   const navigate = useNavigate()
+  const [searchParams, setSearchParams] = useSearchParams()
+  const page = Number(searchParams.get("page") ?? "1")
 
-  const { data, isLoading, error } = useGetMyBookingsQuery()
+  const { data, isLoading, error } = useGetMyBookingsQuery(page - 1)
 
   const handleClick = (bookingId: number) => {
     navigate(`/mypage/bookings/${bookingId}`)
+  }
+
+  const handlePageChange = (newPage: number) => {
+    setSearchParams({ page: newPage.toString() })
   }
 
   if (isLoading || !data) {
@@ -29,7 +36,7 @@ const MyBookingsPage = () => {
     <div className="px-160 mb-48">
       <h1 className="title-24-bold pt-48">내 예매 내역</h1>
       <div className="flex flex-col gap-24 py-32">
-        {data.map((booking: Ticket) => {
+        {data.content.map((booking: Ticket) => {
           return (
             <li
               key={booking.bookingId}
@@ -40,6 +47,15 @@ const MyBookingsPage = () => {
             </li>
           )
         })}
+      </div>
+
+      <div className="flex justify-center">
+        <Pagination
+          current={data.page + 1}
+          total={data.totalCount}
+          pageSize={10}
+          onChange={(p) => handlePageChange(p)}
+        />
       </div>
     </div>
   )


### PR DESCRIPTION
## ✏️ 작업 개요  
이번 PR에서 작업한 내용을 간단히 요약해주세요.

## 🔨 작업 내용 상세
- 예매 내역 조회 페이지네이션 api 연동
- 예매 내역 없을 경우 예외처리: 예매 내역이 없습니다 + 공연 예매하러 가기 버튼

## 🔗 관련 이슈  
- Closes #이슈번호
- #57 

## ✅ 체크리스트  



## 💬 기타 참고 사항  
- 리뷰어가 참고하면 좋을 만한 내용 (예: 테스트 방법, 의도된 예외 처리 등)
